### PR TITLE
Add Trello team link to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# PlusTwoNews
+Charitable, reputable news network.
+
+## Resources
+* [Trello Board](https://trello.com/plustwonews) 


### PR DESCRIPTION
Note that this is a private link; access is restricted to team members. In the future, this may need to be changed if this project gains more contributors.